### PR TITLE
Use install_requires rather than requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,42 +6,38 @@ from setuptools import setup
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='fptest',
-    version='0.1.1',
-    description='A TIBCO Fulfilment Provisioning test helper',
+    name="fptest",
+    version="0.1.1",
+    description="A TIBCO Fulfilment Provisioning test helper",
     long_description=long_description,
-    packages=['fptest'],
-    url='https://github.com/oxo42/FpTest',
-    author='John Oxley',
-    author_email='john.oxley@gmail.com',
-    license='Apache',
-
+    packages=["fptest"],
+    url="https://github.com/oxo42/FpTest",
+    author="John Oxley",
+    author_email="john.oxley@gmail.com",
+    license="Apache",
     classifiers=[
         # How mature is this project? Common values are
         # 3 - Alpha
         # 4 - Beta
         # 5 - Production/Stable
-        'Development Status :: 4 - Beta',
-
+        "Development Status :: 4 - Beta",
         # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Testing',
-
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Testing",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         # 'Programming Language :: Python :: 2',
         # 'Programming Language :: Python :: 2.6',
         # 'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
-
-    requires=['lxml', 'requests']
+    install_requires=["lxml", "requests"],
 )


### PR DESCRIPTION
Use the more accepted install_requires, as this is more accepted around the Python world and certain companies package building dependency detection expects this.
+ black setup.py